### PR TITLE
Rimosso milano

### DIFF
--- a/index.md
+++ b/index.md
@@ -65,7 +65,6 @@ Le lezioni verranno tenute su telegram nel gruppo di [Officine Bitcoin](https://
 |Cremona              |[SatoshiSpritzCremaCremonaLodi](https://t.me/SatoshiSpritzCremaCremonaLodi)|||
 |Lodi                 |[SatoshiSpritzCremaCremonaLodi](https://t.me/SatoshiSpritzCremaCremonaLodi)|||
 |Mantova              |[SatoshiSpritzMantova](https://t.me/satoshispritzmantova)|||
-|Milano               |[SatoshiSpritzMilano](https://t.me/SatoshiSpritzMilano)||[satoshispritz.com](https://satoshispritz.com)|
 |Monza                |[SatoshiSpritzMonza](https://t.me/SatoshiSpritzMonza)|||
 |Piemonte||||
 |Bardonecchia         |[SatoshiSpritzBardonecchia](https://t.me/satoshispritzbardonecchia)|||

--- a/map.html
+++ b/map.html
@@ -17,7 +17,6 @@
 		attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>'
 	}).addTo(map);
 
-	L.marker([45.46679408, 9.1903474]).addTo(map).bindPopup('<b>Satoshi Spritz Milano</b><br/><a target="_blank" href="https://t.me/SatoshiSpritzMilano">t.me/SatoshiSpritzMilano</a>');
 	L.marker([45.5834, 9.2759]).addTo(map).bindPopup('<b>Satoshi Spritz Monza</b><br/><a target="_blank" href="https://t.me/SatoshiSpritzMonza">t.me/SatoshiSpritzMonza</a>');
 	L.marker([45.69441368, 9.66842453]).addTo(map).bindPopup('<b>Satoshi Spritz Bergamo</b><br/><a target="_blank" href="https://t.me/SatoshiSpritzBergamo">t.me/SatoshiSpritzBergamo</a>');
 	L.marker([45.15726772, 10.79277363]).addTo(map).bindPopup('<b>Satoshi Spritz Mantova</b><br/><a target="_blank" href="https://t.me/SatoshiSpritzMantova">t.me/SatoshiSpritzMantova</a>');


### PR DESCRIPTION
Rimosso milano per:
- sponsorizzazione piattaforme scambio
- sponsorizzazzione soluzioni KYC
- sponsorizzazione piattaforme scambio scamcoin 

Eventi nel 2023 sponsorizzati da Conio, vedi anche [presentazioni/230222-taproot.pdf](https://github.com/valerio-vaccaro/satoshispritz.it/blob/main/presentazioni/230222-taproot.pdf)